### PR TITLE
Upgrade to Karpenter 0.16.3

### DIFF
--- a/deployment/aws-terraform/0-hardware/cluster.tf
+++ b/deployment/aws-terraform/0-hardware/cluster.tf
@@ -4,6 +4,7 @@ module "k8s" {
   app_name=var.project_prefix
   environment=var.environment
   aws_region=var.aws_region
+  cluster_version=var.cluster_version
   num_base_instances=var.num_base_instances
   base_instance_type=var.base_instance_type
   user_map=var.user_map

--- a/deployment/aws-terraform/0-hardware/variables.tf
+++ b/deployment/aws-terraform/0-hardware/variables.tf
@@ -13,6 +13,12 @@ variable "project_prefix" {
   description="The project name prefix used to identify cluster resources.  This will be set by wrapper scripts; avoid setting in the .tfvars file!"
 }
 
+variable "cluster_version" {
+  type = string
+  description = "The Kubernetes version to deploy"
+  default = null
+}
+
 variable "num_base_instances" {
   type = number
   description = "Number of instances to be provided in the base group"
@@ -24,11 +30,6 @@ variable "base_instance_type" {
   description = "The instance type to use for the always-on core instance running system pods"
   default = "t3.medium"
 }
-
-# variable "worker_instance_types" {
-#   type=list(string)
-#   description="The menu of node instance types for worker nodes"
-# }
 
 variable "user_map" {
   type = list(object({username: string, userarn: string, groups: list(string)}))

--- a/deployment/aws-terraform/1-services/irsa.tf
+++ b/deployment/aws-terraform/1-services/irsa.tf
@@ -1,0 +1,29 @@
+# These EBS-CSI plugin configs are here because they require the Kubernetes TF
+# plugin, which needs to be configured with information from the 0-hardware stage
+module "ebs_csi_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+
+  role_name = "ebs-csi-${local.cluster_name}"
+  attach_ebs_csi_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
+    }
+  }
+
+  tags = local.tags
+}
+
+resource "kubernetes_annotations" "ebs_csi_iam_annotation" {
+  api_version = "v1"
+  kind = "ServiceAccount"
+  metadata {
+    name = "ebs-csi-controller-sa"
+    namespace = "kube-system"
+  }
+  annotations = {
+    "eks.amazonaws.com/role-arn": module.ebs_csi_irsa.iam_role_arn
+  }
+}

--- a/deployment/aws-terraform/1-services/karpenter.tf
+++ b/deployment/aws-terraform/1-services/karpenter.tf
@@ -83,7 +83,8 @@ module "karpenter_controller_irsa_role" {
   role_name                          = "karpenter-controller"
   attach_karpenter_controller_policy = true
 
-  karpenter_controller_cluster_id         = module.eks.id
+  karpenter_tag_key = "karpenter.sh/discovery/${local.cluster_name}"
+  karpenter_controller_cluster_id = module.eks.id
   karpenter_controller_node_iam_role_arns = [module.eks.base_node_iam_role_arn]
 
   oidc_providers = {
@@ -123,6 +124,7 @@ resource "kubectl_manifest" "karpenter_provisioner" {
         "aws:eks:cluster-name": ${local.cluster_name}
       tags:
         ${var.project_prefix}/kubernetes: 'provisioner'
+        karpenter.sh/discovery/${module.eks.id}: ${module.eks.id}
       instanceProfile:
         KarpenterNodeInstanceProfile-${local.cluster_name}
     ttlSecondsAfterEmpty: 30

--- a/deployment/aws-terraform/1-services/providers.tf
+++ b/deployment/aws-terraform/1-services/providers.tf
@@ -7,10 +7,27 @@ terraform {
   }
 
   required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.10.0"
+    }
+
     kubectl = {
       source  = "gavinbunney/kubectl"
       version = "~> 1.14"
     }
+  }
+}
+
+provider "kubernetes" {
+  host                   = module.eks.endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    # This requires the awscli to be installed locally where Terraform is executed
+    args = ["eks", "get-token", "--cluster-name", module.eks.id]
   }
 }
 

--- a/deployment/aws-terraform/1-services/variables.tf
+++ b/deployment/aws-terraform/1-services/variables.tf
@@ -15,7 +15,7 @@ variable "project_prefix" {
 
 variable "karpenter_chart_version" {
   type = string
-  default = "v0.6.3"
+  default = "v0.16.3"
 }
 
 variable "worker_instance_types" {

--- a/modules/aws/infrastructure/eks.tf
+++ b/modules/aws/infrastructure/eks.tf
@@ -15,6 +15,7 @@ module "eks" {
       resolve_conflicts        = "OVERWRITE"
       service_account_role_arn = module.vpc_cni_irsa.iam_role_arn
     }
+    aws-ebs-csi-driver = {}
   }
 
   # cluster_encryption_config = [{
@@ -27,6 +28,8 @@ module "eks" {
     # Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2006
     # Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2008
     Name = var.app_name
+    GithubRepo = var.repo_name
+    GithubOrg = "azavea"
   }
 
   vpc_id     = module.vpc.vpc_id

--- a/modules/aws/infrastructure/inputs.tf
+++ b/modules/aws/infrastructure/inputs.tf
@@ -20,7 +20,7 @@ variable "repo_name" {
 
 variable "cluster_version" {
   type = string
-  default = "1.22"
+  default = "1.23"
 }
 
 variable "num_base_instances" {


### PR DESCRIPTION
Having noticed that my installed version of Karpenter was ten releases back (for shame!), I've updated the default version.  This PR is on top of #17, so the diff will be a bit confounded until that is merged.