### PR TITLE
Use the correct pangeo base image for Daskhub

### DIFF
--- a/deployment/aws-terraform/application/daskhub/docker/Dockerfile.pangeo_s3contents
+++ b/deployment/aws-terraform/application/daskhub/docker/Dockerfile.pangeo_s3contents
@@ -1,8 +1,7 @@
 ARG PANGEO_VERSION
-FROM pangeo/base-notebook:$PANGEO_VERSION
+FROM pangeo/pangeo-notebook:$PANGEO_VERSION
 
-RUN pip3 install s3contents xarray zarr geopandas matplotlib rechunker tqdm pyproj pyarrow fastparquet
-# RUN conda init
-# RUN conda activate notebook && \
-#     conda install -n notebook -y xarray zarr geopandas matplotlib rechunker tqdm pyproj
+#RUN conda init
+#RUN conda install -y expat gdal
+RUN pip3 install s3contents fastparquet psycopg2-binary
 COPY --chmod=444 jupyter_notebook_config.py /etc/jupyter/jupyter_notebook_config.py

--- a/deployment/aws-terraform/application/daskhub/variables.tf
+++ b/deployment/aws-terraform/application/daskhub/variables.tf
@@ -40,7 +40,7 @@ variable "letsencrypt_contact_email" {
 
 variable "pangeo_notebook_version" {
   type = string
-  description = "Version of pangeo"
+  description = "Version of pangeo-notebook image"
   default = "2022.05.18"
 }
 


### PR DESCRIPTION
I made a boo-boo earlier and was basing our notebook images on too primitive of an image.  This moves to the correct base image, which fixes a bunch of stuff that wasn't working properly.  This also simplifies the customization of the working environment.