### PR TITLE
Upgrade JupyterHub chart version to 2.0.0, add ephemeral scratch space to singleuser environment

### DIFF
--- a/deployment/aws-terraform/application/daskhub/daskhub.tf
+++ b/deployment/aws-terraform/application/daskhub/daskhub.tf
@@ -12,7 +12,7 @@ resource "helm_release" "jupyterhub" {
   name       = "jupyterhub"
   repository = "https://jupyterhub.github.io/helm-chart/"
   chart      = "jupyterhub"
-  version    = "1.2.0"
+  version    = "2.0.0"
   timeout    = 600
 
   # All static settings belong in the following YAML

--- a/deployment/aws-terraform/application/daskhub/yaml/jupyterhub-values.yaml
+++ b/deployment/aws-terraform/application/daskhub/yaml/jupyterhub-values.yaml
@@ -1,6 +1,3 @@
-rbac:
-  enabled: true
-
 proxy:
   service:
     type: LoadBalancer
@@ -64,6 +61,23 @@ singleuser:
   defaultUrl: "/lab"  # Use jupyterlab by default.
   storage:
     type: none
+    extraVolumeMounts:
+      - mountPath: "/scratch"
+        name: scratch-volume
+    extraVolumes:
+      - name: scratch-volume
+        ephemeral:
+          volumeClaimTemplate:
+            metadata:
+              labels:
+                type: jupyter-singleuser-scratch
+            spec:
+              accessModes: ["ReadWriteOnce"]
+              storageClassName: gp2
+              volumeMode: Filesystem
+              resources:
+                requests:
+                  storage: 128Gi
   memory:
     guarantee: 8G
   nodeSelector:

--- a/deployment/aws-terraform/docker-compose.yml
+++ b/deployment/aws-terraform/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     environment:
       - AWS_PROFILE
       - AWS_DEFAULT_REGION
-      - PROJECT_NAME=${PROJECT_NAME:-azavea}
+      - PROJECT_NAME=${PROJECT_NAME:-noaa}
       - ENVIRONMENT
       - DEBUG
       - EDITOR=vi

--- a/deployment/aws-terraform/scripts/console
+++ b/deployment/aws-terraform/scripts/console
@@ -23,7 +23,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         export ENVIRONMENT=${ENVIRONMENT:-$PROVIDED_ENV}
         CONFIGURED_REGION=$(aws configure get region)
         export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-$CONFIGURED_REGION}
-        BUCKET_PREFIX=${BUCKET_PREFIX:-azavea-kubernetes-settings}
+        BUCKET_PREFIX=${BUCKET_PREFIX:-noaa-kubernetes-settings}
         export S3_SETTINGS_BUCKET=${S3_SETTINGS_BUCKET:-${BUCKET_PREFIX}-${AWS_DEFAULT_REGION}}
         export DOCKER_GID=$(getent group docker | awk -F: '{print $3}')
 


### PR DESCRIPTION
This update moves to the most recent JupyterHub Helm chart release.  This move was needed to allow for the addition of an [ephemeral volume](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes) to give notebooks a scratch volume.  This volume is backed by a mount from EBS that has a lifecycle to match the pod it is connected to.  It will not persist after a session expires.  It is currently sized at 128GB, but that value can be changed if needed.

From a notebook environment, it is accessible at `/scratch`:
```
jovyan@jupyter-jpolchlopek-40azavea-2ecom:~$ ls /
bin   dev  home  lib32  libx32  mnt  proc  run   scratch  sys  usr
boot  etc  lib   lib64  media   opt  root  sbin  srv      tmp  var
jovyan@jupyter-jpolchlopek-40azavea-2ecom:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
overlay          20G  9.6G   11G  48% /
tmpfs            64M     0   64M   0% /dev
tmpfs           7.7G     0  7.7G   0% /sys/fs/cgroup
/dev/nvme1n1    252G   24K  252G   1% /scratch
/dev/nvme0n1p1   20G  9.6G   11G  48% /etc/hosts
shm              64M  4.0K   64M   1% /dev/shm
tmpfs            15G  4.0K   15G   1% /run/secrets/eks.amazonaws.com/serviceaccount
tmpfs           7.7G     0  7.7G   0% /proc/acpi
tmpfs           7.7G     0  7.7G   0% /sys/firmware
```
(This is from an earlier test when I was using 256GB as the default size.)

Closes #20 
Connects azavea/noaa-hydro-data#85