### PR TITLE
Enable Dask jobs to run via Argo

### DIFF
--- a/deployment/aws-terraform/application/daskhub/daskhub.tf
+++ b/deployment/aws-terraform/application/daskhub/daskhub.tf
@@ -2,6 +2,16 @@ resource "random_id" "daskhub_token" {
   byte_length = 32
 }
 
+resource "kubernetes_secret" "dashub_auth_token" {
+  metadata {
+    namespace = "daskhub"
+    name = "auth-token"
+  }
+  data = {
+    token = random_id.daskhub_token.hex
+  }
+}
+
 resource "helm_release" "jupyterhub" {
   depends_on       = [
     module.eks.kubeconfig

--- a/deployment/aws-terraform/application/daskhub/docker/Dockerfile.pangeo_s3contents
+++ b/deployment/aws-terraform/application/daskhub/docker/Dockerfile.pangeo_s3contents
@@ -1,7 +1,10 @@
 ARG PANGEO_VERSION
 FROM pangeo/pangeo-notebook:$PANGEO_VERSION
 
-#RUN conda init
-#RUN conda install -y expat gdal
+USER root
+RUN apt-get update && apt-get install -y p7zip
+USER jovyan
+
 RUN pip3 install s3contents fastparquet psycopg2-binary
+RUN pip3 install py3dep==0.13.7 pynhd==0.13.7 pygeohydro==0.13.7 pydaymet==0.13.7 pygeoogc==0.13.7 pygeoutils==0.13.7 async_retriever
 COPY --chmod=444 jupyter_notebook_config.py /etc/jupyter/jupyter_notebook_config.py

--- a/deployment/aws-terraform/application/daskhub/yaml/dask-gateway-values.yaml
+++ b/deployment/aws-terraform/application/daskhub/yaml/dask-gateway-values.yaml
@@ -15,9 +15,15 @@ gateway:
       def option_handler(options):
           return {
               "worker_memory": int(options.worker_memory * 2**30),
+              "worker_cores": int(options.worker_cores),
+              "scheduler_cores": int(options.scheduler_cores),
+              "scheduler_memory": int(options.scheduler_memory * 2**30)
           }
       c.Backend.cluster_options = Options(
           Integer("worker_memory", default=4, min=1, max=31, label="Worker memory (GB)"),
+          Integer("worker_cores", default=1, min=1, max=8, label="Number of cores per worker"),
+          Integer("scheduler_memory", default=8, min=1, max=31, label="Scheduler memory (GB)"),
+          Integer("scheduler_cores", default=1, min=1, max=8, label="Number of cores for scheduler"),
           handler=option_handler,
       )
       c.KubeClusterConfig.idle_timeout = 1800
@@ -46,6 +52,10 @@ gateway:
                     operator: In
                     values:
                       - worker
+                  - key: disk-size
+                    operator: In
+                    values:
+                      - large
 
 traefik:
   nodeSelector:

--- a/deployment/aws-terraform/application/daskhub/yaml/dask-gateway-values.yaml
+++ b/deployment/aws-terraform/application/daskhub/yaml/dask-gateway-values.yaml
@@ -42,6 +42,10 @@ gateway:
                     values:
                       - worker
     worker:
+      extraContainerConfig:
+        env:
+        - name: MALLOC_TRIM_THRESHOLD_ # See https://github.com/pangeo-data/rechunker/issues/100#issuecomment-933832834
+          value: "0"
       extraPodConfig:
         affinity:
           nodeAffinity:

--- a/deployment/aws-terraform/application/daskhub/yaml/jupyterhub-values.yaml
+++ b/deployment/aws-terraform/application/daskhub/yaml/jupyterhub-values.yaml
@@ -79,7 +79,7 @@ singleuser:
                 requests:
                   storage: 128Gi
   memory:
-    guarantee: 8G
+    guarantee: 16G
   nodeSelector:
     node-type: worker
   extraEnv:


### PR DESCRIPTION
This is a bit of a mishmash of changes that are in support of allowing Argo to run Dask jobs.  The substance of this PR is largely to tune the Dask setup to be more resilient to larger jobs (e.g., adjusting disk sizes to handle spilling to disk), but there is also a workflow template (pending commit at the time of initial creation of this PR) which sets up a framework for downloading a source file via http(s) and executing the Dask job contained within.  The framework mostly configures environment variables for the workflow so that jobs can connect relatively effortlessly.  Other env vars are included to allow for job parameters to be configured as part of launching the workflow, rather than requiring source changes (these use the `DASK_OPTS__` prefix).  The configurable options of the Dask gateway are modified to support richer configurations.

- [ ] ~~Add variable to enable the installation of Argo templates in the Daskhub application (requires that `application/argo` be properly applied to the cluster first)~~
- [ ] ~~Add a ClusterWorkflowTemplate that provides the structure for running a Dask job~~