### PR TITLE
Revert NOAA-specific changes merged into master

### DIFF
--- a/deployment/aws-terraform/docker-compose.yml
+++ b/deployment/aws-terraform/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     environment:
       - AWS_PROFILE
       - AWS_DEFAULT_REGION
-      - PROJECT_NAME=${PROJECT_NAME:-noaa}
+      - PROJECT_NAME=${PROJECT_NAME:-azavea}
       - ENVIRONMENT
       - DEBUG
       - EDITOR=vi

--- a/deployment/aws-terraform/scripts/console
+++ b/deployment/aws-terraform/scripts/console
@@ -23,7 +23,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         export ENVIRONMENT=${ENVIRONMENT:-$PROVIDED_ENV}
         CONFIGURED_REGION=$(aws configure get region)
         export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-$CONFIGURED_REGION}
-        BUCKET_PREFIX=${BUCKET_PREFIX:-noaa-kubernetes-settings}
+        BUCKET_PREFIX=${BUCKET_PREFIX:-azavea-kubernetes-settings}
         export S3_SETTINGS_BUCKET=${S3_SETTINGS_BUCKET:-${BUCKET_PREFIX}-${AWS_DEFAULT_REGION}}
         export DOCKER_GID=$(getent group docker | awk -F: '{print $3}')
 


### PR DESCRIPTION
This reverts commit 9978dc5062fa310f4b370b393613c378b48b798e.  These changes were accidentally committed back into master with #20.  This is not the first time, indicating that extra care needs to be taken to rebase changes to master that were tested on a deployment-specific branch (in this case `deployment/noaa`).  This indicates the need for a PR template.