### PR TITLE
Install EFS CSI plugin

### DIFF
--- a/deployment/aws-terraform/1-services/efs-csi.tf
+++ b/deployment/aws-terraform/1-services/efs-csi.tf
@@ -20,3 +20,12 @@ resource "helm_release" "efs_csi_driver" {
     value = "602401143452.dkr.ecr.${var.aws_region}.amazonaws.com/eks/aws-efs-csi-driver"
   }
 }
+
+resource  "kubernetes_storage_class_v1" "efs_sc" {
+  metadata {
+    name = "efs-sc"
+  }
+  storage_provisioner = "efs.csi.aws.com"
+
+  depends_on = [ helm_release.efs_csi_driver ]
+}

--- a/deployment/aws-terraform/1-services/efs-csi.tf
+++ b/deployment/aws-terraform/1-services/efs-csi.tf
@@ -1,4 +1,5 @@
 resource "helm_release" "efs_csi_driver" {
+  count = local.use_efs
   namespace        = "kube-system"
 
   name       = "aws-efs-csi-driver"
@@ -22,10 +23,12 @@ resource "helm_release" "efs_csi_driver" {
 }
 
 resource  "kubernetes_storage_class_v1" "efs_sc" {
+  count = local.use_efs
+
   metadata {
     name = "efs-sc"
   }
   storage_provisioner = "efs.csi.aws.com"
 
-  depends_on = [ helm_release.efs_csi_driver ]
+  depends_on = [ helm_release.efs_csi_driver[0] ]
 }

--- a/deployment/aws-terraform/1-services/efs-csi.tf
+++ b/deployment/aws-terraform/1-services/efs-csi.tf
@@ -1,0 +1,22 @@
+resource "helm_release" "efs_csi_driver" {
+  namespace        = "kube-system"
+
+  name       = "aws-efs-csi-driver"
+  repository = "https://kubernetes-sigs.github.io/aws-efs-csi-driver/"
+  chart      = "aws-efs-csi-driver"
+
+  set {
+    name  = "controller.serviceAccount.name"
+    value = "efs-csi-controller-sa"
+  }
+
+  set {
+    name  = "node.serviceAccount.name"
+    value = "efs-csi-node-sa"
+  }
+
+  set {
+    name  = "image.repository"
+    value = "602401143452.dkr.ecr.${var.aws_region}.amazonaws.com/eks/aws-efs-csi-driver"
+  }
+}

--- a/deployment/aws-terraform/1-services/irsa.tf
+++ b/deployment/aws-terraform/1-services/irsa.tf
@@ -1,5 +1,6 @@
-# These EBS-CSI plugin configs are here because they require the Kubernetes TF
-# plugin, which needs to be configured with information from the 0-hardware stage
+# The EBS CSI plugin IRSA configs are here, and not in 0—hardware where the EBS
+# CSI plugin was installed, because they require the Kubernetes TF provider,
+# which needs to be configured with outputs from the 0-hardware stage
 module "ebs_csi_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
 
@@ -25,5 +26,65 @@ resource "kubernetes_annotations" "ebs_csi_iam_annotation" {
   }
   annotations = {
     "eks.amazonaws.com/role-arn": module.ebs_csi_irsa.iam_role_arn
+  }
+}
+
+module "efs_csi_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+
+  role_name_prefix      = "efs-csi-${local.cluster_name}"
+  attach_efs_csi_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = [
+        "kube-system:efs-csi-controller-sa"
+      ]
+    }
+  }
+
+  tags = local.tags
+}
+
+module "efs_csi_irsa_node" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+
+  role_name_prefix      = "efs-csi-node-${local.cluster_name}"
+  attach_efs_csi_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = [
+        "kube-system:efs-csi-node-sa"
+      ]
+    }
+  }
+
+  tags = local.tags
+}
+
+resource "kubernetes_annotations" "efs_csi_iam_annotation" {
+  api_version = "v1"
+  kind = "ServiceAccount"
+  metadata {
+    name = "efs-csi-controller-sa"
+    namespace = "kube-system"
+  }
+  annotations = {
+    "eks.amazonaws.com/role-arn": module.efs_csi_irsa.iam_role_arn
+  }
+}
+
+resource "kubernetes_annotations" "efs_csi_node_annotation" {
+  api_version = "v1"
+  kind = "ServiceAccount"
+  metadata {
+    name = "efs-csi-node-sa"
+    namespace = "kube-system"
+  }
+  annotations = {
+    "eks.amazonaws.com/role-arn": module.efs_csi_irsa_node.iam_role_arn
   }
 }

--- a/deployment/aws-terraform/1-services/irsa.tf
+++ b/deployment/aws-terraform/1-services/irsa.tf
@@ -30,6 +30,8 @@ resource "kubernetes_annotations" "ebs_csi_iam_annotation" {
 }
 
 module "efs_csi_irsa" {
+  count = local.use_efs
+
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
 
   role_name_prefix      = "efs-csi-${local.cluster_name}"
@@ -48,6 +50,8 @@ module "efs_csi_irsa" {
 }
 
 module "efs_csi_irsa_node" {
+  count = local.use_efs
+
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
 
   role_name_prefix      = "efs-csi-node-${local.cluster_name}"
@@ -66,6 +70,8 @@ module "efs_csi_irsa_node" {
 }
 
 resource "kubernetes_annotations" "efs_csi_iam_annotation" {
+  count = local.use_efs
+
   api_version = "v1"
   kind = "ServiceAccount"
   metadata {
@@ -73,11 +79,13 @@ resource "kubernetes_annotations" "efs_csi_iam_annotation" {
     namespace = "kube-system"
   }
   annotations = {
-    "eks.amazonaws.com/role-arn": module.efs_csi_irsa.iam_role_arn
+    "eks.amazonaws.com/role-arn": module.efs_csi_irsa[0].iam_role_arn
   }
 }
 
 resource "kubernetes_annotations" "efs_csi_node_annotation" {
+  count = local.use_efs
+
   api_version = "v1"
   kind = "ServiceAccount"
   metadata {
@@ -85,6 +93,6 @@ resource "kubernetes_annotations" "efs_csi_node_annotation" {
     namespace = "kube-system"
   }
   annotations = {
-    "eks.amazonaws.com/role-arn": module.efs_csi_irsa_node.iam_role_arn
+    "eks.amazonaws.com/role-arn": module.efs_csi_irsa_node[0].iam_role_arn
   }
 }

--- a/deployment/aws-terraform/1-services/locals.tf
+++ b/deployment/aws-terraform/1-services/locals.tf
@@ -2,6 +2,7 @@ locals {
   cluster_name = "${var.project_prefix}-${var.environment}"
   db_count = var.create_rds_instance ? 1 : 0
   cognito_pool_count = var.create_cognito_pool ? 1 : 0
+  use_efs = var.use_efs_csi ? 1 : 0
 
   tags = {
     Name    = var.project_prefix

--- a/deployment/aws-terraform/1-services/network.tf
+++ b/deployment/aws-terraform/1-services/network.tf
@@ -1,0 +1,19 @@
+data "aws_vpc" "cluster_vpc" {
+  id = module.eks.vpc_id
+}
+
+resource "aws_security_group" "efs" {
+  name = "EFS inbound"
+  description = "EFS inbound traffic"
+  vpc_id = module.eks.vpc_id
+
+  ingress {
+    description = "NFS traffic"
+    from_port = 2049
+    to_port = 2049
+    protocol = "tcp"
+    cidr_blocks = [data.aws_vpc.cluster_vpc.cidr_block]
+  }
+
+  tags = local.tags
+}

--- a/deployment/aws-terraform/1-services/variables.tf
+++ b/deployment/aws-terraform/1-services/variables.tf
@@ -44,6 +44,12 @@ variable "google_identity_client_secret" {
   description = "Client ID for Google identity provider"
 }
 
+variable "use_efs_csi" {
+  type = bool
+  description = "Install EFS CSI driver"
+  default = false
+}
+
 variable "r53_rds_private_hosted_zone" {
   type = string
   default = null

--- a/modules/aws/infrastructure/eks.tf
+++ b/modules/aws/infrastructure/eks.tf
@@ -1,5 +1,6 @@
 module "eks" {
-  source          = "terraform-aws-modules/eks/aws"
+  source = "terraform-aws-modules/eks/aws"
+  version = "18.31.2"
 
   cluster_name                    = local.cluster_name
   cluster_version                 = var.cluster_version


### PR DESCRIPTION
We have previously installed the EBS CSI add-on to the cluster in order to create persistent volumes backed by EBS volumes.  These are useful, but lack some ability to share across multiple nodes/pods.  A potentially more robust solution for volumes that host data that may be consumed by multiple users concurrently (especially if the consuming pods span multiple nodes) is EFS.  To allow for a storage class backed by EFS, we need to introduce the EFS CSI driver.

Once this driver is installed, it will be possible to use the `efs-sc` storage class to mount EFS-backed volumes.  For those volumes to be available, an EFS file system and mount points need to be created and given proper security group access.  This will be left as a task to those deployments which need an EFS volume.  This PR simply provides the driver to make EFS storage a possibility.